### PR TITLE
Replace first occurrence only of a env

### DIFF
--- a/backup/src/fr/webcenter/backup/Backup.py
+++ b/backup/src/fr/webcenter/backup/Backup.py
@@ -115,7 +115,7 @@ class Backup(object):
                 logger.info("Dumping %s/%s in %s" % (dump['service']['stack']['name'], dump['service']['name'], dump['target_dir']))
                 environments = ""
                 for env in dump['environments']:
-                    environments += " -e '%s'" % env.replace(':', '=')
+                    environments += " -e '%s'" % env.replace(':', '=', 1)
     
     
                 if 'entrypoint' in dump:


### PR DESCRIPTION
Replacement should occur only with the first occurrence of the symbol, otherwise the value of the variable is distorted.