### PR TITLE
Fix missing services

### DIFF
--- a/backup/src/fr/webcenter/backup/Rancher.py
+++ b/backup/src/fr/webcenter/backup/Rancher.py
@@ -36,12 +36,12 @@ class Rancher(object):
         :return list The list of services
         """
 
-        listServices = self._client.list('service')
+        listServices = self._client.list('service', kind='service', state='active')
 
         # We keep only enable services and services that have not 'backup.disable' label set to true
         targetListServices = []
         for service in listServices:
-            if service["type"] == "service" and "imageUuid" in service['launchConfig'] and  service["state"] == "active" and ("labels" not in service['launchConfig'] or ("backup.disable" not in service['launchConfig']['labels'] or service['launchConfig']['labels']['backup.disable'] == "false")):
+            if "imageUuid" in service['launchConfig'] and ("labels" not in service['launchConfig'] or ("backup.disable" not in service['launchConfig']['labels'] or service['launchConfig']['labels']['backup.disable'] == "false")):
 
                 logger.debug("Found service %s", service["name"])
 


### PR DESCRIPTION
I have an environment where we have ~250 services. The Cattle API list services endpoint has a default pagination limit of 100 when no filters are provided therefore a number of our services aren't being "found" and therefore not backed up.

By moving the filtering from the for loop and into the API call we a reduce the number of entries we need to compare, plus it appears to negate the limit.